### PR TITLE
add rotation-ordering util

### DIFF
--- a/pymo/preprocessing.py
+++ b/pymo/preprocessing.py
@@ -98,6 +98,10 @@ class MocapParameterizer(BaseEstimator, TransformerMixin):
                                      f[1]['%s_Yrotation'%joint], 
                                      f[1]['%s_Zrotation'%joint]] for f in rc.iterrows()]
 
+                    ################# in euler angle, the order of rotation axis is very important #####################
+                    rotation_order = rc.columns[0][rc.columns[0].find('rotation') - 1] + rc.columns[1][rc.columns[1].find('rotation') - 1] + rc.columns[2][rc.columns[2].find('rotation') - 1] #rotation_order is string : 'XYZ' or'ZYX' or ...
+                    ####################################################################################################
+
                 if pc.shape[1] < 3:
                     pos_values = [[0,0,0] for f in pc.iterrows()]
                 else:
@@ -109,7 +113,9 @@ class MocapParameterizer(BaseEstimator, TransformerMixin):
                 #pos_values = [[0,0,0] for f in pc.iterrows()] #for deugging
                 
                 # Convert the eulers to rotation matrices
-                rotmats = np.asarray([Rotation([f[0], f[1], f[2]], 'euler', from_deg=True).rotmat for f in euler_values])                  
+                ############################ input rotation order as Rotation class's argument #########################
+                rotmats = np.asarray([Rotation([f[0], f[1], f[2]], 'euler', rotation_order, from_deg=True).rotmat for f in euler_values])
+                ########################################################################################################
                 tree_data[joint]=[
                                     [], # to store the rotation matrix
                                     []  # to store the calculated position

--- a/pymo/rotation_tools.py
+++ b/pymo/rotation_tools.py
@@ -18,8 +18,9 @@ def rad2deg(x):
     return x/math.pi*180
 
 class Rotation():
-    def __init__(self,rot, param_type, **params):
+    def __init__(self,rot, param_type, rotation_order, **params):
         self.rotmat = []
+        self.rotation_order = rotation_order
         if param_type == 'euler':
             self._from_euler(rot[0],rot[1],rot[2], params)
         elif param_type == 'expmap':
@@ -55,10 +56,15 @@ class Rotation():
 
         self.rotmat = np.eye(3)
 
-        self.rotmat = np.matmul(Rx, self.rotmat)
-        self.rotmat = np.matmul(Ry, self.rotmat)
-        self.rotmat = np.matmul(Rz, self.rotmat)
-        # self.rotmat = np.matmul(np.matmul(Rz, Ry), Rx)
+        ############################ inner product rotation matrix in order defined at BVH file #########################
+        for axis in self.rotation_order :
+            if axis == 'X' :
+                self.rotmat = np.matmul(Rx, self.rotmat)
+            elif axis == 'Y':
+                self.rotmat = np.matmul(Ry, self.rotmat)
+            else :
+                self.rotmat = np.matmul(Rz, self.rotmat)
+        ################################################################################################################
    
     def _from_expmap(self, alpha, beta, gamma, params):
         if (alpha == 0 and beta == 0 and gamma == 0):


### PR DESCRIPTION
When I tried to transform some BVH files, There was a problem that the positions of joints are located very strangely.

Now I find the reason, there is a problem in 'rotation_tools.py'
The problem is that you only considered about BVH file that have 'XYZ-order' in rotation channel.
Actually, there are BVH file that have 'ZYX-order' or 'ZXY-order' or etc... too.

As you know, in rotation matrix, the joining order of single-axis rotation matrix is very important(commutative law is not valid). 

So, I just add one parameter named 'rotation_order' at class 'Rotation', and add a simple 'For Clause' at  'rotation_tools.py' to make a correct order.
And, to give argument to 'Rotation', I modify 'preprocessin.py' very a little bit.

I wish your 'PyMO' contributing to more people.
Thank you for sharing good open-source.

-demul