### PR TITLE
add MANIFEST.in to include pymo/mocapplayer/* when running setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include pymo/mocapplayer *

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,16 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://omid.al/projects/PyMO.html",
     packages=setuptools.find_packages(),
+    include_package_data=True,    # include files in MANIFEST.in
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ),
+    install_requires=[    # dependencies
+        'numpy',
+        'pandas',
+        'matplotlib',
+        'scikit-learn'
+    ]
 )


### PR DESCRIPTION
Include pymo/mocapplayer/* when installing by running " sudo pip setup.py install".