### PR TITLE
Capitalize End Site in BVH file

### DIFF
--- a/pymo/writers.py
+++ b/pymo/writers.py
@@ -30,7 +30,7 @@ class BVHWriter():
         elif len(X.skeleton[joint]['children']) > 0:
             ofile.write('%sJOINT %s\n'%('\t'*(tab), joint))
         else:
-            ofile.write('%sEnd site\n'%('\t'*(tab)))
+            ofile.write('%sEnd Site\n'%('\t'*(tab)))
 
         ofile.write('%s{\n'%('\t'*(tab)))
         


### PR DESCRIPTION
Thank you for this great project, it really helped us a lot for our project [RoseMotion](https://github.com/seanschneeweiss/RoSeMotion).

Matlab requires to use `End Site` in the BVH file, so that the BVH importer identifies the end of the skeleton.

Do you think this change could break the behavior of other tools?